### PR TITLE
Fix edge normal mode

### DIFF
--- a/addons/ply/resources/ply_mesh.gd
+++ b/addons/ply/resources/ply_mesh.gd
@@ -52,10 +52,10 @@ func edge(i: int) -> Array:
 	return [edge_origin(i), edge_destination(i)]
 
 
-func edge_normal(e: int) -> Array:
+func edge_normal(e: int) -> Vector3:
 	var face_normal_left = face_normal(edge_face_left(e))
 	var face_normal_right = face_normal(edge_face_right(e))
-	return [(face_normal_left + face_normal_right) / 2]
+	return (face_normal_left + face_normal_right) / 2
 
 
 func face_count() -> int:


### PR DESCRIPTION
Returns a Vector3 in the function 'edge_normal' instead of an Array.

Note: I used 3.4 branch for this.