### PR TITLE
Allow triangulation starting at 2nd vertex

### DIFF
--- a/addons/ply/gui/toolbar/toolbar.gd
+++ b/addons/ply/gui/toolbar/toolbar.gd
@@ -44,7 +44,8 @@ var plugin: EditorPlugin
 @onready var face_extrude = $Scroll/Content/FaceTools/Extrude
 @onready var face_connect = $Scroll/Content/FaceTools/Connect
 @onready var face_subdivide = $Scroll/Content/FaceTools/Subdivide
-@onready var face_triangulate = $Scroll/Content/FaceTools/Triangulate
+@onready var face_triangulate_regular = $Scroll/Content/FaceTools/Triangulate/Regular
+@onready var face_triangulate_offset = $Scroll/Content/FaceTools/Triangulate/Offset
 
 @onready var face_set_shape_1 = $"Scroll/Content/FaceTools/Surfaces/1"
 @onready var face_set_shape_2 = $"Scroll/Content/FaceTools/Surfaces/2"
@@ -103,7 +104,8 @@ func _ready() -> void:
 	face_extrude.connect("pressed",Callable(self,"_face_extrude"))
 	face_connect.connect("pressed",Callable(self,"_face_connect"))
 	face_subdivide.connect("pressed",Callable(self,"_face_subdivide"))
-	face_triangulate.connect("pressed",Callable(self,"_face_triangulate"))
+	face_triangulate_regular.connect("pressed",Callable(self,"_face_triangulate_regular"))
+	face_triangulate_offset.connect("pressed",Callable(self,"_face_triangulate_offset"))
 
 	edge_select_loop.connect("pressed",Callable(self,"_edge_select_loop"))
 	edge_cut_loop.connect("pressed",Callable(self,"_edge_cut_loop"))
@@ -332,7 +334,7 @@ func _face_subdivide():
 	)
 
 
-func _face_triangulate():
+func _face_triangulate_regular():
 	if plugin.ignore_inputs:
 		return
 	if not plugin.selection or selection_mode != SelectionMode.FACE:
@@ -340,6 +342,16 @@ func _face_triangulate():
 	var pre_edit = plugin.selection.ply_mesh.begin_edit()
 	Triangulate.faces(plugin.selection.ply_mesh, plugin.selection.selected_faces)
 	plugin.selection.ply_mesh.commit_edit("Triangulate Faces", plugin.get_undo_redo(), pre_edit)
+
+
+func _face_triangulate_offset():
+	if plugin.ignore_inputs:
+		return
+	if not plugin.selection or selection_mode != SelectionMode.FACE:
+		return
+	var pre_edit = plugin.selection.ply_mesh.begin_edit()
+	Triangulate.faces(plugin.selection.ply_mesh, plugin.selection.selected_faces, 1)
+	plugin.selection.ply_mesh.commit_edit("Triangulate Faces (Offset +1)", plugin.get_undo_redo(), pre_edit)
 
 
 func _set_face_surface(s):

--- a/addons/ply/gui/toolbar/toolbar.tscn
+++ b/addons/ply/gui/toolbar/toolbar.tscn
@@ -469,11 +469,24 @@ text = "Subdivide"
 icon = ExtResource( "13_68wte" )
 expand_icon = true
 
-[node name="Triangulate" type="Button" parent="Scroll/Content/FaceTools"]
+[node name="Triangulate" type="HBoxContainer" parent="Scroll/Content/FaceTools"]
 offset_top = 358.0
 offset_right = 192.0
 offset_bottom = 389.0
+
+[node name="Regular" type="Button" parent="Scroll/Content/FaceTools/Triangulate"]
+offset_right = 161.0
+offset_bottom = 31.0
+size_flags_horizontal = 3
 text = "Triangulate"
+icon = ExtResource( "14_8ytvm" )
+expand_icon = true
+
+[node name="Offset" type="Button" parent="Scroll/Content/FaceTools/Triangulate"]
+offset_left = 165.0
+offset_right = 192.0
+offset_bottom = 31.0
+text = "+1"
 icon = ExtResource( "14_8ytvm" )
 expand_icon = true
 

--- a/addons/ply/resources/triangulate.gd
+++ b/addons/ply/resources/triangulate.gd
@@ -8,9 +8,13 @@ static func object(ply_mesh):
 	return faces(ply_mesh, f)
 
 
-static func faces(ply_mesh, face_indices) -> void:
+static func faces(ply_mesh, face_indices, offset = 0) -> void:
 	for face_idx in face_indices:
 		var verts = ply_mesh.face_vertex_indexes(face_idx)
+		for o in range(offset):
+			var v = verts[0]
+			verts.remove_at(0)
+			verts.push_back(v)
 		while verts.size() > 3:
 			var min_dot = null
 			var min_pair = null


### PR DESCRIPTION
While the difference is neglectable in many cases, this is most notable when triangulating quads, as this allows you to switch the diagonal you want to create (from first to third vertex or from second to fourth).

By default, when triangulating quads, you'd always get this diagonal:
![Triangulation (regular)](https://user-images.githubusercontent.com/1854245/180611020-7da19a27-85d1-46ce-9569-009e1aa83fae.png)

However, in some cases you might prefer to triangulate in the other direction, e.g. to block out some specific diagonal/geometry.

To achieve this, the new, smaller `+1` button will essentially offset the triangulation by 1, moving the first vertex per face to the end:
![Triangulation (offset +1)](https://user-images.githubusercontent.com/1854245/180611064-08c1a1f0-d8c1-49e8-88d6-c5d4926e5779.png)

_There might be a better way to do this – or maybe it's even included and I haven't found it yet, but I wanted to try this to block out a test level (or even more). Let me know what you think or if I indeed missed something obvious!_