### PR TITLE
Fix compatibility with Godot 4.0 beta 16

### DIFF
--- a/addons/ply/resources/extrude.gd
+++ b/addons/ply/resources/extrude.gd
@@ -1,5 +1,5 @@
 const Side = preload("res://addons/ply/utils/direction.gd")
-
+const PlyMesh = preload("res://addons/ply/resources/ply_mesh.gd")
 
 static func faces(ply_mesh: PlyMesh, faces, undo_redo = null, distance = 1) -> void:
 	# walk the outside of the faces:


### PR DESCRIPTION
Currently, `extrude.gd` cant run properly due to the fact that on `line 4` it references `PlyMesh`, which it cant find on its own, so a script preload with class definition is necessary to get this to work.