### PR TITLE
Fix selection visuals

### DIFF
--- a/addons/ply/plugin.gd
+++ b/addons/ply/plugin.gd
@@ -81,16 +81,10 @@ var selection	# nullable PlyEditor
 
 
 func _edit(o: Object) -> void:
-	if o == null:
-		selection.selected = false
-		selection = null
-		emit_signal("selection_changed", null)
-		return
-
 	if selection:
 		selection.selected = false
+
 	selection = o
-	selection.selected = true
 	emit_signal("selection_changed", selection)
 
 

--- a/addons/ply/plugin.gd
+++ b/addons/ply/plugin.gd
@@ -81,19 +81,21 @@ var selection	# nullable PlyEditor
 
 
 func _edit(o: Object) -> void:
-	if not o is PlyEditor:
+	if o == null:
+		selection.selected = false
+		selection = null
+		emit_signal("selection_changed", null)
 		return
+
+	if selection:
+		selection.selected = false
 	selection = o
+	selection.selected = true
 	emit_signal("selection_changed", selection)
 
 
 func _make_visible(vis: bool) -> void:
 	toolbar.visible = vis
-	if selection and selection.get_property_list().has("selected"):
-		selection.selected = vis
-	if not vis:
-		selection = null
-		emit_signal("selection_changed", null)
 
 
 var ignore_inputs = false


### PR DESCRIPTION
Opening this project in Godot 4 RC2 caused a bunch of changes in all of the import files, adding some new `high_quality` setting, so I separated them in a different commit.

It seems at some point `_edit` was changed so that it will give you a null variant to indicate that you are no longer selecting a valid object. I think it's better to reset the visibility of the selection there rather than `_make_visible` because:
 * `_make_visible` is called before `_edit`, so when selecting a PlyEditor node, `selection` is null (because it was reset by the last call to _edit) and as such we can't make it visible.
 * Docs recommend using `_edit` to clean up state when the variant is null.

I tested the changes with multiple `PlyEditor` nodes and everything seems to be working correctly.
