### PR TITLE
Disable shadow casting of vertices and edges

### DIFF
--- a/addons/ply/nodes/ply_vertices.gd
+++ b/addons/ply/nodes/ply_vertices.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	m.use_point_size = true
 	m.point_size = 10
 	m.vertex_color_use_as_albedo = true
-	m.cast_shadow = false
+	cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 
 func _process(_delta) -> void:

--- a/addons/ply/nodes/ply_wireframe.gd
+++ b/addons/ply/nodes/ply_wireframe.gd
@@ -11,6 +11,7 @@ func _ready() -> void:
 	# m.flags_no_depth_test = true # enable for xray
 	m.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
 	m.vertex_color_use_as_albedo = true
+	cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 
 func _process(_delta) -> void:


### PR DESCRIPTION
`cast_shadow` is not a property of the material but of `GeometryInstance3D` which ply_vertices.gd inhertis. Also disabled shadows on edges.