### PR TITLE
Set selected to true on the new selection

### DIFF
--- a/addons/ply/plugin.gd
+++ b/addons/ply/plugin.gd
@@ -81,14 +81,15 @@ var selection	# nullable PlyEditor
 
 
 func _edit(o: Object) -> void:
-    if selection and not selection.is_queued_for_deletion():
-        selection.selected = false
-
-    if o == null:
-        toolbar.visible = false
-    else:
-        selection = o
-        emit_signal("selection_changed", selection)
+	if selection and not selection.is_queued_for_deletion():
+		selection.selected = false
+	
+	if o == null:
+		toolbar.visible = false
+	else:
+		selection = o
+		selection.selected = true
+		emit_signal("selection_changed", selection)
 
 
 func _make_visible(vis: bool) -> void:


### PR DESCRIPTION
My previous PR(#79) correctly fixed (#81) but for some reason some changes were applied to it and broke it. The important line here is 91, which sets selected to true, which then calls the setter and creates the necessary visuals for the selection. Also, the entire `plugin.gd` file is formatted with spaces, while the rest of the files are formatted with tabs. I kept the tabs here because i think the spaces were be a mistake, if not let me know.